### PR TITLE
docs: add CI and crates.io badges to README header

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
-# Scribble
+# Scribble &emsp; [![Build Status]][actions] [![Latest Version]][crates.io]
+
+[Build Status]: https://img.shields.io/github/actions/workflow/status/itsmontoya/scribble/ci.yml?branch=master
+[actions]: https://github.com/itsmontoya/scribble/actions?query=branch%3Amaster
+[Latest Version]: https://img.shields.io/crates/v/scribble.svg
+[crates.io]: https://crates.io/crates/scribble
 
 Scribble is a fast, lightweight transcription engine written in Rust, built on top of Whisper and designed for both CLI and webserver use.
 


### PR DESCRIPTION
This PR updates the README header to improve visibility into Scribble’s health and release status.

**Changes:**
- Adds a GitHub Actions CI badge to show current build status
- Adds a crates.io version badge for quick access to the latest published release
- Cleans up the README header formatting for better readability

No functional changes — documentation only.
