### PR TITLE
chore(ci): remove unused release finalization job

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -168,17 +168,3 @@ jobs:
       - name: Note (token missing)
         if: env.CARGO_REGISTRY_TOKEN == ''
         run: echo "CARGO_REGISTRY_TOKEN not set; skipping crates.io publish."
-
-  finalize:
-    name: Finalize release
-    needs:
-      - tag_and_release
-      - publish
-    if: needs.publish.result == 'success' || needs.publish.result == 'skipped'
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Publish draft release
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: gh release edit "${{ needs.tag_and_release.outputs.tag }}" --draft=false


### PR DESCRIPTION
This PR removes the `finalize` job from the release workflow.

The removed job was responsible for:
- Waiting on `tag_and_release` and `publish`
- Publishing a draft GitHub release via `gh release edit`

Since releases are no longer created as drafts (or are finalized elsewhere), this step is redundant and no longer required.

Removing it:
- Simplifies the release pipeline
- Eliminates an unnecessary dependency on the GitHub CLI
- Reduces workflow complexity and potential points of failure

No functional changes to the release or publish behavior result from this update.
