### PR TITLE
chore(ci): fix Build Status links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Scribble &emsp; [![Build Status]][actions] [![Latest Version]][crates.io]
 
-[Build Status]: https://img.shields.io/github/actions/workflow/status/itsmontoya/scribble/ci.yml?branch=main
+[Build Status]: https://img.shields.io/github/actions/workflow/status/itsmontoya/scribble/ci.yaml?branch=main
 [actions]: https://github.com/itsmontoya/scribble/actions?query=branch%3Amain
 [Latest Version]: https://img.shields.io/crates/v/scribble.svg
 [crates.io]: https://crates.io/crates/scribble


### PR DESCRIPTION
# Summary 
Fixed the GitHub Actions Build Status links to reference the correct YAML extension (yml -> yaml)