### PR TITLE
Update README to reflect audio/video support and generic input examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Scribble is a fast, lightweight transcription engine written in Rust, built on t
 
 ![billboard](https://github.com/itsmontoya/scribble/blob/main/banner.png?raw=true "Scribble billboard")
 
+Scribble will demux/decode **audio *or* video containers** (MP4, MP3, WAV, FLAC, OGG, WebM, MKV, etc.), downmix to mono, and resample to Whisper’s expected 16 kHz — no preprocessing required.
+
 ## Goals
 
 - Provide a clean, idiomatic Rust API for audio transcription  
@@ -30,7 +32,7 @@ cargo build --release
 
 This will produce the following binaries:
 
-- `scribble-cli` — transcribe WAV files
+- `scribble-cli` — transcribe audio/video (decodes + normalizes to mono 16 kHz)
 - `model-downloader` — download Whisper and VAD models
 
 ## model-downloader
@@ -84,9 +86,9 @@ Downloads are performed safely:
 
 `scribble-cli` is the main transcription CLI.
 
-It expects:
+It accepts audio or video containers and normalizes them to Whisper’s required mono 16 kHz internally. Provide:
 
-- a **mono, 16 kHz WAV file**
+- an input media path (e.g. MP4, MP3, WAV, FLAC, OGG, WebM, MKV) or `-` to stream from stdin
 - a Whisper model
 - (optionally) a Whisper-VAD model
 
@@ -95,7 +97,7 @@ It expects:
 ```bash
 cargo run --bin scribble-cli -- \
   --model ./models/ggml-large-v3-turbo.bin \
-  --audio ./audio.wav
+  --input ./input.mp4
 ```
 
 Output is written to `stdout` in WebVTT format by default.
@@ -105,7 +107,7 @@ Output is written to `stdout` in WebVTT format by default.
 ```bash
 cargo run --bin scribble-cli -- \
   --model ./models/ggml-large-v3-turbo.bin \
-  --audio ./audio.wav \
+  --input ./input.wav \
   --output-type json
 ```
 
@@ -116,7 +118,7 @@ cargo run --bin scribble-cli -- \
   --model ./models/ggml-large-v3-turbo.bin \
   --vad-model ./models/ggml-silero-v6.2.0.bin \
   --enable-vad \
-  --audio ./audio.wav
+  --input ./input.wav
 ```
 
 When VAD is enabled:
@@ -129,7 +131,7 @@ When VAD is enabled:
 ```bash
 cargo run --bin scribble-cli -- \
   --model ./models/ggml-large-v3-turbo.bin \
-  --audio ./audio.wav \
+  --input ./input.wav \
   --language en
 ```
 
@@ -140,7 +142,7 @@ If `--language` is omitted, Whisper will auto-detect.
 ```bash
 cargo run --bin scribble-cli -- \
   --model ./models/ggml-large-v3-turbo.bin \
-  --audio ./audio.wav \
+  --input ./input.wav \
   --output-type vtt \
   > transcript.vtt
 ```


### PR DESCRIPTION
- Document that Scribble now decodes audio and video containers and normalizes to mono 16 kHz.
- Update `scribble-cli` usage examples to use `--input` with generic `input.wav`/`input.mp4` paths instead of ignored samples.
- Clarify binary summary to note decoding/normalization in the CLI.

**Testing**
- Not run (docs-only).
