### PR TITLE
Expose next_speaker_turn on Segment and populate from Whisper

### DIFF
--- a/src/segments.rs
+++ b/src/segments.rs
@@ -29,6 +29,12 @@ pub struct Segment {
     /// Today we default this because we are not yet running per-segment language detection.
     /// When we add language detection, we can populate this field more accurately.
     pub language_code: String,
+
+    /// True if the next segment begins a new speaker turn.
+    ///
+    /// Populated from `WhisperSegment::next_segment_speaker_turn()` so downstream
+    /// encoders/UIs can insert speaker breaks without re-deriving this signal.
+    pub next_speaker_turn: bool,
 }
 
 /// Our current placeholder language code.
@@ -112,6 +118,7 @@ pub fn to_segment(segment: WhisperSegment) -> Result<Segment> {
         text,
         tokens,
         language_code: DEFAULT_LANGUAGE_CODE.to_owned(),
+        next_speaker_turn: segment.next_segment_speaker_turn(),
     })
 }
 


### PR DESCRIPTION
## Summary
Expose a per-segment speaker-turn signal from Whisper and surface it on our `Segment` so downstream consumers can insert speaker breaks without heuristics.

## Changes
- Add `next_speaker_turn: bool` to `Segment` (`src/segments.rs`).
- Populate `Segment.next_speaker_turn` via `WhisperSegment::next_segment_speaker_turn()` in `to_segment` (`src/segments.rs`).
- Document the field to clarify its source and intended downstream use.

## Rationale
- Avoids ad-hoc pause/punctuation heuristics in consumers by carrying Whisper’s own speaker-turn signal.
- Makes it straightforward for encoders/UIs to render speaker boundaries.

## Output Impact
- JSON: Segment objects now include a `next_speaker_turn` boolean.
- VTT: Unchanged (still uses segment-level timings and text).

Example (truncated):
```json
{
  "start_seconds": 1.23,
  "end_seconds": 3.45,
  "text": "Hello world",
  "language_code": "und",
  "next_speaker_turn": true,
  "tokens": [
    { "start_seconds": 1.23, "end_seconds": 1.56, "text": " Hello", "probability": 0.98 }
  ]
}
