### PR TITLE
chore(release): v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1423,7 +1423,7 @@ dependencies = [
 
 [[package]]
 name = "scribble"
-version = "0.1.5"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scribble"
-version = "0.1.5"
+version = "0.2.0"
 edition = "2024"
 
 description = "High-level Rust API for audio transcription using Whisper"


### PR DESCRIPTION
Automated version bump for v0.2.0 (from PR #46).