### PR TITLE
chore(release): v0.4.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1539,7 +1539,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scribble"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scribble"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2024"
 
 description = "High-level Rust API for audio transcription using Whisper"


### PR DESCRIPTION
Automated version bump for v0.4.2 (from PR #62).