### PR TITLE
scribble-server: drop /v1 from HTTP routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ cargo run --features bin-scribble-server --bin scribble-server -- \
 
 ```bash
 curl -sS --data-binary @./input.mp4 \
-  "http://127.0.0.1:8080/v1/transcribe?output=vtt" \
+  "http://127.0.0.1:8080/transcribe?output=vtt" \
   > transcript.vtt
 ```
 
@@ -148,7 +148,7 @@ For JSON output:
 
 ```bash
 curl -sS --data-binary @./input.wav \
-  "http://127.0.0.1:8080/v1/transcribe?output=json" \
+  "http://127.0.0.1:8080/transcribe?output=json" \
   > transcript.json
 ```
 
@@ -156,7 +156,7 @@ Example using all query params:
 
 ```bash
 curl -sS --data-binary @./input.mp4 \
-  "http://127.0.0.1:8080/v1/transcribe?output=json&output_type=json&model_key=ggml-large-v3-turbo.bin&enable_vad=true&translate_to_english=true&language=en" \
+  "http://127.0.0.1:8080/transcribe?output=json&output_type=json&model_key=ggml-large-v3-turbo.bin&enable_vad=true&translate_to_english=true&language=en" \
   > transcript.json
 ```
 

--- a/src/bin/scribble-server/main.rs
+++ b/src/bin/scribble-server/main.rs
@@ -143,10 +143,10 @@ async fn run() -> Result<()> {
 
     let app = Router::new()
         .route("/", get(root))
-        .route("/healthz", get(healthz))
+        .route("/health", get(health))
         .route("/metrics", get(metrics::prometheus_metrics))
-        .route("/v1/models", get(models))
-        .route("/v1/transcribe", post(transcribe))
+        .route("/models", get(models))
+        .route("/transcribe", post(transcribe))
         .route_layer(from_fn(metrics::track_http_metrics))
         .with_state(state)
         .layer(DefaultBodyLimit::max(params.max_bytes))
@@ -169,10 +169,10 @@ async fn run() -> Result<()> {
 }
 
 async fn root() -> &'static str {
-    "scribble-server: POST /v1/transcribe (multipart field: file)"
+    "scribble-server: POST /transcribe (multipart field: file)"
 }
 
-async fn healthz() -> &'static str {
+async fn health() -> &'static str {
     "ok"
 }
 

--- a/src/bin/scribble-server/metrics.rs
+++ b/src/bin/scribble-server/metrics.rs
@@ -124,7 +124,7 @@ pub async fn track_http_metrics(req: Request<Body>, next: Next) -> Response {
         .unwrap_or_else(|| req.uri().path())
         .to_owned();
 
-    if route == "/metrics" || route == "/healthz" {
+    if route == "/metrics" || route == "/health" {
         return next.run(req).await;
     }
 


### PR DESCRIPTION
## Summary
- Simplifies `scribble-server` HTTP routes by removing the `/v1` prefix and standardizing the health endpoint to `/health`.

## Why
- We want stable, cleaner paths for a small surface-area API.
- `/health` is the more common default for basic service health checks.

## Changes
- Removed `/v1` prefix from routes:
  - `GET /v1/models` -> `GET /models`
  - `POST /v1/transcribe` -> `POST /transcribe`
- Renamed health endpoint:
  - `GET /healthz` -> `GET /health`
- Updated metrics middleware skip-list to match.
- Updated README examples to use the new endpoints.

## Behavior / API impact
- Breaking change: `/v1/*` endpoints are removed; clients must switch to `/models` and `/transcribe`.
- Breaking change: `/healthz` is removed; health checks must switch to `/health`.

## Edge cases considered
- Metrics collection continues to exclude health/metrics endpoints to avoid skewing request stats.

## Testing
- [x] cargo fmt --all -- --check
- [x] cargo clippy --all-targets --all-features -- -D warnings
- [x] cargo check --all-features
- [x] cargo test --all-features
- [x] Cargo.lock updated (if dependencies changed)
- Ran: `cargo test --workspace`
