### PR TITLE
docs(readme): add Rust Report Card badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Scribble &emsp; [![Build Status]][actions] [![Coverage]][actions] [![Latest Version]][crates.io] [![Docs Badge]][Docs URL] [![MIT licensed][License Badge]][License URL]
+# Scribble &emsp; [![Build Status]][actions] [![Coverage]][actions] [![Latest Version]][crates.io] [![Docs Badge]][Docs URL] [![Report Card Badge]][Report Card URL] [![MIT licensed][License Badge]][License URL]
 
 [Build Status]: https://img.shields.io/github/actions/workflow/status/itsmontoya/scribble/ci.yaml?branch=main
 [actions]: https://github.com/itsmontoya/scribble/actions?query=branch%3Amain
@@ -9,6 +9,8 @@
 [License URL]: https://github.com/itsmontoya/scribble/blob/main/LICENSE
 [Docs Badge]: https://img.shields.io/badge/docs.rs-scribble-CE422B
 [Docs URL]: https://docs.rs/scribble/latest/scribble/
+[Report Card URL]: https://rust-reportcard.xuri.me/report/github.com/itsmontoya/scribble
+[Report Card Badge]: https://rust-reportcard.xuri.me/badge/github.com/itsmontoya/scribble
 
 Scribble is a fast, lightweight transcription engine written in Rust, with a built-in Whisper backend and a backend trait for custom implementations.
 


### PR DESCRIPTION
## Summary
- Add a Rust Report Card badge to the README header.

## Why
- Surface a quick, at-a-glance signal for Rust best-practices/lints and overall project hygiene.

## Changes
- README: add Rust Report Card badge + link target.

## Behavior / API impact
- None (documentation-only).

## Edge cases considered
- None.

## Testing
- [ ] cargo fmt --all -- --check (N/A — docs-only)
- [ ] cargo clippy --all-targets --all-features -- -D warnings (N/A — docs-only)
- [ ] cargo check --all-features (N/A — docs-only)
- [ ] cargo test --all-features (N/A — docs-only)
- [ ] Cargo.lock updated (if dependencies changed) (N/A)

## Follow-ups
- None.
