### PR TITLE
chore(release): v0.5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1576,7 +1576,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scribble"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "audioadapter",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scribble"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 rust-version = "1.85"
 


### PR DESCRIPTION
Automated version bump for v0.5.1 (from PR #91).