### PR TITLE
feat(streaming): add emit_single_segments option for low-latency use cases

### DIFF
--- a/src/backends/whisper/incremental.rs
+++ b/src/backends/whisper/incremental.rs
@@ -135,12 +135,15 @@ impl<'a> BufferedSegmentTranscriber<'a> {
             .context("whisper returned a negative segment count")?;
 
         // Finalization rule:
-        // - If Whisper produced >= 2 segments, treat all but the last as “final”.
+        // - If Whisper produced >= 2 segments, treat all but the last as "final".
         // - At end-of-stream (or max-buffer cap), flush everything available.
+        // - If emit_single_segments is enabled, also emit when there's exactly 1 segment.
         let emit_count = if force_flush {
             n_segments
         } else if n_segments >= 2 {
             n_segments - 1
+        } else if n_segments == 1 && self.opts.emit_single_segments {
+            1
         } else {
             0
         };

--- a/src/bin/scribble-cli.rs
+++ b/src/bin/scribble-cli.rs
@@ -32,6 +32,7 @@ fn run() -> Result<()> {
         language: params.language.clone(),
         output_type: params.output_type,
         incremental_min_window_seconds: 1,
+        emit_single_segments: false,
     };
 
     // Open an input source.

--- a/src/bin/scribble-server/main.rs
+++ b/src/bin/scribble-server/main.rs
@@ -214,6 +214,7 @@ async fn transcribe(
         language: query.language,
         output_type,
         incremental_min_window_seconds: 1,
+        emit_single_segments: false,
     };
 
     let content_type = match opts.output_type {

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -44,4 +44,15 @@ pub struct Opts {
     /// This only affects the streaming/incremental path (when VAD is disabled). Larger windows
     /// increase latency but can improve segmentation stability.
     pub incremental_min_window_seconds: usize,
+
+    /// Whether to emit single segments immediately in incremental mode.
+    ///
+    /// By default (`false`), the incremental transcriber waits for 2+ segments before emitting,
+    /// treating the last segment as potentially incomplete. This provides better accuracy for
+    /// long-form transcription but adds latency for short utterances.
+    ///
+    /// When `true`, single segments are emitted as soon as detected. This is useful for
+    /// voice assistants and real-time applications where low latency is more important than
+    /// waiting for sentence boundaries.
+    pub emit_single_segments: bool,
 }

--- a/src/scribble.rs
+++ b/src/scribble.rs
@@ -292,6 +292,7 @@ mod tests {
             language: None,
             output_type,
             incremental_min_window_seconds: 1,
+            emit_single_segments: false,
         }
     }
 

--- a/tests/scribble.rs
+++ b/tests/scribble.rs
@@ -56,6 +56,7 @@ fn transcribes_wav_to_json_variants() -> anyhow::Result<()> {
                 language: None,
                 output_type: OutputType::Json,
                 incremental_min_window_seconds: 1,
+                emit_single_segments: false,
             },
         ),
         (
@@ -67,6 +68,7 @@ fn transcribes_wav_to_json_variants() -> anyhow::Result<()> {
                 language: None,
                 output_type: OutputType::Json,
                 incremental_min_window_seconds: 1,
+                emit_single_segments: false,
             },
         ),
         (
@@ -78,6 +80,7 @@ fn transcribes_wav_to_json_variants() -> anyhow::Result<()> {
                 language: Some("en".to_string()),
                 output_type: OutputType::Json,
                 incremental_min_window_seconds: 1,
+                emit_single_segments: false,
             },
         ),
         (
@@ -89,6 +92,7 @@ fn transcribes_wav_to_json_variants() -> anyhow::Result<()> {
                 language: Some("en".to_string()),
                 output_type: OutputType::Json,
                 incremental_min_window_seconds: 1,
+                emit_single_segments: false,
             },
         ),
     ];


### PR DESCRIPTION
## Summary

- Adds `emit_single_segments` option to enable low-latency streaming use cases
- When enabled, emits individual segments as they are recognized rather than batching

## Context

This feature is used by the [Friday project](https://gitlab.com/lx-industries/friday).

---

*This PR was created with the assistance of an AI assistant (Claude).*