### PR TITLE
feat(vad): drop silent audio windows to prevent hallucinations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2469,6 +2469,7 @@ version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71ea5d2401f30f51d08126a2d133fee4c1955136519d7ac6cf6f5ac0a91e6bc8"
 dependencies = [
+ "libc",
  "whisper-rs-sys",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,13 @@ bin-scribble-server = [
   "dep:tower-http",
 ]
 
+# GPU acceleration features (pass-through to whisper-rs).
+cuda = ["whisper-rs/cuda"]
+metal = ["whisper-rs/metal"]
+hipblas = ["whisper-rs/hipblas"]
+vulkan = ["whisper-rs/vulkan"]
+coreml = ["whisper-rs/coreml"]
+
 [[bin]]
 name = "scribble-cli"
 path = "src/bin/scribble-cli.rs"

--- a/src/backends/whisper/incremental.rs
+++ b/src/backends/whisper/incremental.rs
@@ -135,12 +135,15 @@ impl<'a> BufferedSegmentTranscriber<'a> {
             .context("whisper returned a negative segment count")?;
 
         // Finalization rule:
-        // - If Whisper produced >= 2 segments, treat all but the last as “final”.
+        // - If Whisper produced >= 2 segments, treat all but the last as "final".
         // - At end-of-stream (or max-buffer cap), flush everything available.
+        // - If emit_single_segments is enabled, also emit when there's exactly 1 segment.
         let emit_count = if force_flush {
             n_segments
         } else if n_segments >= 2 {
             n_segments - 1
+        } else if n_segments == 1 && self.opts.emit_single_segments {
+            1
         } else {
             0
         };

--- a/src/bin/scribble-cli.rs
+++ b/src/bin/scribble-cli.rs
@@ -32,6 +32,7 @@ fn run() -> Result<()> {
         language: params.language.clone(),
         output_type: params.output_type,
         incremental_min_window_seconds: 1,
+            emit_single_segments: false,
     };
 
     // Open an input source.

--- a/src/bin/scribble-cli.rs
+++ b/src/bin/scribble-cli.rs
@@ -32,7 +32,7 @@ fn run() -> Result<()> {
         language: params.language.clone(),
         output_type: params.output_type,
         incremental_min_window_seconds: 1,
-            emit_single_segments: false,
+        emit_single_segments: false,
     };
 
     // Open an input source.

--- a/src/bin/scribble-server/main.rs
+++ b/src/bin/scribble-server/main.rs
@@ -214,7 +214,7 @@ async fn transcribe(
         language: query.language,
         output_type,
         incremental_min_window_seconds: 1,
-            emit_single_segments: false,
+        emit_single_segments: false,
     };
 
     let content_type = match opts.output_type {

--- a/src/bin/scribble-server/main.rs
+++ b/src/bin/scribble-server/main.rs
@@ -214,6 +214,7 @@ async fn transcribe(
         language: query.language,
         output_type,
         incremental_min_window_seconds: 1,
+            emit_single_segments: false,
     };
 
     let content_type = match opts.output_type {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,3 +75,4 @@ pub use crate::output_type::OutputType;
 pub use crate::scribble::Scribble;
 pub use crate::segment_encoder::SegmentEncoder;
 pub use crate::segments::Segment;
+pub use crate::vad::{VadProcessor, VadStream, VadStreamReceiver};

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -44,4 +44,15 @@ pub struct Opts {
     /// This only affects the streaming/incremental path (when VAD is disabled). Larger windows
     /// increase latency but can improve segmentation stability.
     pub incremental_min_window_seconds: usize,
+
+    /// Whether to emit single segments immediately in incremental mode.
+    ///
+    /// By default (`false`), the incremental transcriber waits for 2+ segments before emitting,
+    /// treating the last segment as potentially incomplete. This provides better accuracy for
+    /// long-form transcription but adds latency for short utterances.
+    ///
+    /// When `true`, single segments are emitted as soon as detected. This is useful for
+    /// voice assistants and real-time applications where low latency is more important than
+    /// waiting for sentence boundaries.
+    pub emit_single_segments: bool,
 }

--- a/src/samples_rx.rs
+++ b/src/samples_rx.rs
@@ -8,6 +8,11 @@
 //! When VAD is enabled, keep the same control flow, just with a different source of samples.
 //! `SamplesRx` provides a receiver-like shape without introducing trait objects or implicit
 //! behavior.
+//!
+//! Note: With VAD now handled inside the backend stream, this module is currently unused
+//! but kept for potential future use cases.
+
+#![allow(dead_code)]
 
 use std::sync::mpsc;
 

--- a/src/scribble.rs
+++ b/src/scribble.rs
@@ -292,6 +292,7 @@ mod tests {
             language: None,
             output_type,
             incremental_min_window_seconds: 1,
+            emit_single_segments: false,
         }
     }
 

--- a/src/scribble.rs
+++ b/src/scribble.rs
@@ -21,9 +21,7 @@ use crate::decoder::{SamplesSink, StreamDecodeOpts, decode_to_stream_from_read};
 use crate::json_array_encoder::JsonArrayEncoder;
 use crate::opts::Opts;
 use crate::output_type::OutputType;
-use crate::samples_rx::SamplesRx;
 use crate::segment_encoder::SegmentEncoder;
-use crate::vad::{VadProcessor, VadStreamReceiver};
 use crate::vtt_encoder::VttEncoder;
 
 /// The main high-level transcription entry point.
@@ -36,7 +34,6 @@ use crate::vtt_encoder::VttEncoder;
 /// - Call `transcribe` many times with different inputs and outputs.
 pub struct Scribble<B: Backend> {
     backend: B,
-    vad_model_path: Option<String>,
 }
 
 impl Scribble<WhisperBackend> {
@@ -49,22 +46,15 @@ impl Scribble<WhisperBackend> {
         I: IntoIterator<Item = P>,
         P: AsRef<str>,
     {
-        let vad_model_path = vad_model_path.as_ref();
-        let backend = WhisperBackend::new(model_paths, vad_model_path)?;
-        Ok(Self {
-            backend,
-            vad_model_path: Some(vad_model_path.to_owned()),
-        })
+        let backend = WhisperBackend::new(model_paths, vad_model_path.as_ref())?;
+        Ok(Self { backend })
     }
 }
 
 impl<B: Backend> Scribble<B> {
     /// Create a new `Scribble` instance using a custom backend.
     pub fn with_backend(backend: B) -> Self {
-        Self {
-            backend,
-            vad_model_path: None,
-        }
+        Self { backend }
     }
 
     /// Transcribe an input stream and write the result to an output writer.
@@ -109,11 +99,11 @@ impl<B: Backend> Scribble<B> {
         E: SegmentEncoder,
     {
         let backend = &self.backend;
-        let vad = Self::get_vad(self.vad_model_path.as_deref(), opts)?;
 
         // Decode on a dedicated thread to overlap I/O + decode with backend inference.
         // Keep orchestration and error plumbing on the calling thread.
-        let (mut rx, decode_handle) = Self::get_samples_rx(r, opts, vad)?;
+        // Note: VAD filtering is now handled inside the backend stream when enabled.
+        let (rx, decode_handle) = Self::get_samples_rx(r)?;
 
         let mut stream = backend.create_stream(opts, encoder)?;
 
@@ -143,37 +133,13 @@ impl<B: Backend> Scribble<B> {
         }
     }
 
-    fn get_vad(vad_model_path: Option<&str>, opts: &Opts) -> Result<Option<VadProcessor>> {
-        if !opts.enable_voice_activity_detection {
-            return Ok(None);
-        }
-
-        let Some(vad_model_path) = vad_model_path else {
-            return Err(crate::Error::invalid_input(
-                "VAD is enabled, but no VAD model path is configured for this Scribble instance",
-            ));
-        };
-
-        // Initialize a fresh VAD context per transcription.
-        //
-        // Rationale:
-        // - The upstream `whisper-rs` VAD bindings currently do not mark the VAD context as
-        //   `Send`/`Sync`, making it awkward to store inside long-lived, shared server state.
-        // - Even when upstream adds the necessary guarantees, per-request state may still be
-        //   useful
-        //   (or a pool) to enable true concurrency without a global lock.
-        //
-        // If/when the underlying library provides a clearly shareable VAD context, this can be
-        // revisited to reuse or pool VAD processors for lower latency and less per-request
-        // overhead.
-        Ok(Some(VadProcessor::new(vad_model_path)?))
-    }
-
+    #[allow(clippy::type_complexity)]
     fn get_samples_rx<R>(
         r: R,
-        opts: &Opts,
-        vad: Option<VadProcessor>,
-    ) -> Result<(SamplesRx, std::thread::JoinHandle<Result<()>>)>
+    ) -> Result<(
+        mpsc::Receiver<Vec<f32>>,
+        std::thread::JoinHandle<Result<()>>,
+    )>
     where
         R: Read + Send + 'static,
     {
@@ -181,25 +147,14 @@ impl<B: Backend> Scribble<B> {
         // decoding. This also makes backpressure explicit rather than relying on unbounded queues.
         let (tx, rx) = mpsc::sync_channel::<Vec<f32>>(512);
         let decode_opts = StreamDecodeOpts::default();
-        let emit_frames = decode_opts.target_chunk_frames;
 
         let decode_handle = std::thread::spawn(move || -> Result<()> {
             let mut sink = ChannelSamplesSink { tx };
             decode_to_stream_from_read(r, decode_opts, &mut sink).map_err(Into::into)
         });
 
-        let rx = if opts.enable_voice_activity_detection {
-            // Wrap the decoder receiver so the main loop stays unchanged when VAD is enabled.
-            // `VadStreamReceiver` is responsible for buffering and flushing VAD state.
-            let vad = vad.ok_or_else(|| {
-                crate::Error::invalid_input("VAD is enabled, but VAD failed to initialize")
-            })?;
-            let vad_rx = VadStreamReceiver::new(rx, vad, emit_frames);
-            SamplesRx::Vad(vad_rx)
-        } else {
-            SamplesRx::Plain(rx)
-        };
-
+        // VAD filtering is now handled inside the backend stream when enabled,
+        // so we return raw decoded samples without VAD wrapping.
         Ok((rx, decode_handle))
     }
 
@@ -314,27 +269,6 @@ mod tests {
         assert!(err.to_string().contains("close failed"));
     }
 
-    #[test]
-    fn get_vad_returns_none_when_disabled() -> anyhow::Result<()> {
-        let scribble = Scribble::with_backend(DummyBackend);
-        let opts = default_opts(OutputType::Json);
-        let vad = Scribble::<DummyBackend>::get_vad(scribble.vad_model_path.as_deref(), &opts)?;
-        assert!(vad.is_none());
-        Ok(())
-    }
-
-    #[test]
-    fn get_vad_errors_when_enabled_but_missing_path() {
-        let scribble = Scribble::with_backend(DummyBackend);
-        let mut opts = default_opts(OutputType::Json);
-        opts.enable_voice_activity_detection = true;
-
-        let err =
-            Scribble::<DummyBackend>::get_vad(scribble.vad_model_path.as_deref(), &opts).err();
-        let err = err.expect("expected get_vad() to error");
-        assert!(err.to_string().contains("no VAD model path"));
-    }
-
     struct NoopEncoder;
 
     impl SegmentEncoder for NoopEncoder {
@@ -383,18 +317,6 @@ mod tests {
         ) -> Result<Self::Stream<'a>> {
             Ok(FinishErrStream)
         }
-    }
-
-    #[test]
-    fn get_samples_rx_errors_when_vad_enabled_but_missing_processor() {
-        let mut opts = default_opts(OutputType::Json);
-        opts.enable_voice_activity_detection = true;
-
-        let input = std::io::Cursor::new(Vec::<u8>::new());
-        let err = Scribble::<DummyBackend>::get_samples_rx(input, &opts, None)
-            .err()
-            .expect("expected get_samples_rx() to error");
-        assert!(err.to_string().contains("VAD failed to initialize"));
     }
 
     #[test]

--- a/src/vad/mod.rs
+++ b/src/vad/mod.rs
@@ -12,4 +12,4 @@ mod stream;
 mod to_speech;
 
 pub use processor::VadProcessor;
-pub use stream::VadStreamReceiver;
+pub use stream::{VadStream, VadStreamReceiver};

--- a/src/vad/stream.rs
+++ b/src/vad/stream.rs
@@ -23,7 +23,8 @@ pub struct VadStream {
 }
 
 impl VadStream {
-    pub(crate) fn new(vad: VadProcessor) -> Self {
+    /// Create a new VAD stream adapter.
+    pub fn new(vad: VadProcessor) -> Self {
         const SAMPLE_RATE_HZ: f32 = 16_000.0;
 
         let policy = vad.policy();
@@ -43,12 +44,14 @@ impl VadStream {
         }
     }
 
-    pub(crate) fn push(&mut self, chunk: &[f32]) -> Result<()> {
+    /// Push a chunk of audio samples into the VAD stream.
+    pub fn push(&mut self, chunk: &[f32]) -> Result<()> {
         self.in_buf.extend_from_slice(chunk);
         self.process_ready_windows()
     }
 
-    pub(crate) fn flush(&mut self) -> Result<()> {
+    /// Flush any remaining buffered audio through VAD.
+    pub fn flush(&mut self) -> Result<()> {
         self.process_ready_windows()?;
 
         let mut window = Vec::with_capacity(self.pending_tail.len() + self.in_buf.len());
@@ -69,7 +72,8 @@ impl VadStream {
         Ok(())
     }
 
-    pub(crate) fn peek_chunk(&self, frames: usize) -> Option<&[f32]> {
+    /// Peek at the next chunk of VAD-filtered output without consuming it.
+    pub fn peek_chunk(&self, frames: usize) -> Option<&[f32]> {
         let available = self.out_buf.len().saturating_sub(self.out_cursor);
         if available >= frames {
             Some(&self.out_buf[self.out_cursor..self.out_cursor + frames])
@@ -78,7 +82,8 @@ impl VadStream {
         }
     }
 
-    pub(crate) fn consume_chunk(&mut self, frames: usize) {
+    /// Consume a chunk of VAD-filtered output.
+    pub fn consume_chunk(&mut self, frames: usize) {
         self.out_cursor = (self.out_cursor + frames).min(self.out_buf.len());
 
         // Periodically compact to avoid unbounded growth if the caller consumes in small steps.
@@ -89,7 +94,8 @@ impl VadStream {
         }
     }
 
-    pub(crate) fn peek_remainder(&self) -> Option<&[f32]> {
+    /// Peek at any remaining VAD-filtered output.
+    pub fn peek_remainder(&self) -> Option<&[f32]> {
         if self.out_cursor < self.out_buf.len() {
             Some(&self.out_buf[self.out_cursor..])
         } else {
@@ -97,7 +103,8 @@ impl VadStream {
         }
     }
 
-    pub(crate) fn consume_remainder(&mut self) {
+    /// Consume all remaining VAD-filtered output.
+    pub fn consume_remainder(&mut self) {
         self.out_cursor = self.out_buf.len();
         self.out_buf.clear();
         self.out_cursor = 0;

--- a/tests/scribble.rs
+++ b/tests/scribble.rs
@@ -56,6 +56,7 @@ fn transcribes_wav_to_json_variants() -> anyhow::Result<()> {
                 language: None,
                 output_type: OutputType::Json,
                 incremental_min_window_seconds: 1,
+                emit_single_segments: false,
             },
         ),
         (
@@ -67,6 +68,7 @@ fn transcribes_wav_to_json_variants() -> anyhow::Result<()> {
                 language: None,
                 output_type: OutputType::Json,
                 incremental_min_window_seconds: 1,
+                emit_single_segments: false,
             },
         ),
         (
@@ -78,6 +80,7 @@ fn transcribes_wav_to_json_variants() -> anyhow::Result<()> {
                 language: Some("en".to_string()),
                 output_type: OutputType::Json,
                 incremental_min_window_seconds: 1,
+                emit_single_segments: false,
             },
         ),
         (
@@ -89,6 +92,7 @@ fn transcribes_wav_to_json_variants() -> anyhow::Result<()> {
                 language: Some("en".to_string()),
                 output_type: OutputType::Json,
                 incremental_min_window_seconds: 1,
+                emit_single_segments: false,
             },
         ),
     ];


### PR DESCRIPTION
## Summary

- Applies VAD (Voice Activity Detection) filtering in the backend stream
- Drops silent audio windows to prevent whisper hallucinations during silence
- Improves transcription quality by only processing audio with detected speech

## Dependencies

- Depends on #108 (`fix/emit-single-segments`)

## Context

This feature is used by the [Friday project](https://gitlab.com/lx-industries/friday).

---

*This PR was created with the assistance of an AI assistant (Claude).*