### PR TITLE
Support graceful shutdown in scribble-server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1709,6 +1709,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2083,6 +2093,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
@@ -2151,6 +2162,7 @@ dependencies = [
  "http-body",
  "iri-string",
  "pin-project-lite",
+ "tokio",
  "tower",
  "tower-layer",
  "tower-service",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ tokio = { version = "1", optional = true, features = [
   "io-util",
   "net",
   "sync",
+  "signal",
 ] }
 tokio-util = { version = "0.7", optional = true, features = ["io", "io-util"] }
 futures-util = { version = "0.3", optional = true }
@@ -62,7 +63,7 @@ rubato = "1.0.0"
 symphonia = { version = "0.5", features = ["all"] }
 tempfile = "3"
 prometheus = { version = "0.14", optional = true }
-tower-http = { version = "0.6", optional = true, features = ["trace"] }
+tower-http = { version = "0.6", optional = true, features = ["trace", "timeout"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", optional = true, features = [
   "env-filter",


### PR DESCRIPTION
## Summary
- Add graceful shutdown in axum. (Mostly copied from official axum example: https://github.com/tokio-rs/axum/blob/main/examples/graceful-shutdown/src/main.rs)

## Why
- Prevent dropping active requests
- Zero-downtime deployments

## Testing
- [x] cargo fmt --all -- --check
- [x] cargo clippy --all-targets --features bin-scribble-cli,bin-model-downloader,bin-scribble-server -- -D warnings
- [x] cargo check --features bin-scribble-cli,bin-model-downloader,bin-scribble-server
- [x] ./scripts/test-all.sh
- [x] Cargo.lock updated (if dependencies changed)