### PR TITLE
chore(deps): bump bytes to 1.11.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -249,9 +249,9 @@ checksum = "1fbdf580320f38b612e485521afda1ee26d10cc9884efaaa750d383e13e3c5f4"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"


### PR DESCRIPTION
## Summary
- Bumps the resolved `bytes` crate from `1.11.0` to `1.11.1` in `Cargo.lock`.

## Why
- Pull in the latest patch release of `bytes` for dependency hygiene and upstream fixes.

## Changes
- Updated `Cargo.lock`:
  - `bytes` version `1.11.0` -> `1.11.1`
  - Updated the corresponding crate checksum.

## Behavior / API impact
- No application code changes.
- No expected runtime behavior or API changes from this repo’s code.

## Edge cases considered
- This is a lockfile-only dependency patch update; transitive resolution remains unchanged except for `bytes`.

## Testing
- [ ] cargo fmt --all -- --check
- [ ] cargo clippy --all-targets --features bin-scribble-cli,bin-model-downloader,bin-scribble-server -- -D warnings
- [ ] cargo check --features bin-scribble-cli,bin-model-downloader,bin-scribble-server
- [ ] ./scripts/test-all.sh
- [x] Cargo.lock updated (if dependencies changed)

## Follow-ups
- If desired, run the full verification matrix above before merge.
