### PR TITLE
Fix compilation for windows msvc

### DIFF
--- a/src/backends/whisper/logging.rs
+++ b/src/backends/whisper/logging.rs
@@ -1,20 +1,17 @@
-use std::os::raw::{c_char, c_void};
 use std::sync::Once;
 
-/// A no-op log callback used to silence logs emitted by whisper.cpp.
-unsafe extern "C" fn whisper_log_callback(
-    _level: u32,
-    _c_msg: *const c_char,
-    _user_data: *mut c_void,
-) {
-    // Intentionally left empty.
-}
-
 /// Ensure whisper logging is configured exactly once for the lifetime of the process.
+///
+/// Routes whisper.cpp and GGML logs through whisper-rs's logging hooks. scribble enables
+/// neither the `log_backend` nor `tracing_backend` feature on whisper-rs, so the hooks
+/// compile down to no-ops and the logs are silenced. This is the same observable behavior
+/// as the previous no-op `whisper_log_set` callback: whisper.cpp's `whisper_log_set`
+/// internally forwards to `ggml_log_set`, so both the old and new paths silence the
+/// whisper *and* GGML log streams.
 pub fn init_whisper_logging() {
     static INIT: Once = Once::new();
 
-    INIT.call_once(|| unsafe {
-        whisper_rs::set_log_callback(Some(whisper_log_callback), std::ptr::null_mut());
+    INIT.call_once(|| {
+        whisper_rs::install_logging_hooks();
     });
 }


### PR DESCRIPTION
## Summary
Fix the whisper backend failing to compile on `x86_64-pc-windows-msvc` by replacing the `unsafe extern "C"` log callback with whisper-rs's safe `install_logging_hooks()`.

## Why
- `logging.rs` declared the log callback with `_level: u32`, but `whisper_rs::set_log_callback` expects `ggml_log_callback`, whose level param is `ggml_log_level`. bindgen types that all-non-negative unfixed C enum as `c_uint` (u32) on Linux/macOS/windows-gnu, but as `c_int` (**i32**) under the MSVC ABI. So the hardcoded `u32` only matches non-MSVC targets and the build breaks on windows-msvc:
```
  error[E0308]: mismatched types
     = note: expected fn pointer unsafe extern "C" fn(i32, _, _)
                found fn item unsafe extern "C" fn(u32, _, _) {whisper_log_callback}
```
- whisper-rs already exposes a safe `install_logging_hooks()` and its docs recommend it over
`set_log_callback`, so we can sidestep the platform-dependent FFI type entirely.

## Changes
- Remove the `unsafe extern "C" fn whisper_log_callback` and its `set_log_callback` call.
- `init_whisper_logging()` now calls `whisper_rs::install_logging_hooks()`.
- Drop the now-unused `std::os::raw::{c_char, c_void}` import; update the doc comment.

## Behavior / API impact
- No public API change — `init_whisper_logging()` keeps the same signature and `Once` guard.
- Logs remain silenced on **both** the whisper and GGML streams for scribble's feature set:
the trampolines route through whisper-rs's `generic_*!` macros, which expand to nothing
unless `log_backend`/`tracing_backend` is enabled — and scribble enables neither.
- Behavior is feature-conditional: if a downstream enables `whisper-rs/log_backend` or
`tracing_backend`, the hooks would route logs through that backend instead of hard-silencing
them (opt-in, and arguably the better library default).

## Edge cases considered
- **Both log streams:** whisper.cpp's `whisper_log_set` internally forwards the callback to
`ggml_log_set`, so the old no-op already silenced both — and `install_logging_hooks()`
installs trampolines on both. No regression in coverage.

## Testing
- [x] cargo fmt --all -- --check
- [x] cargo clippy --all-targets --features bin-scribble-cli,bin-model-downloader,bin-scribble-server -- -D warnings
- [x] cargo check --features bin-scribble-cli,bin-model-downloader,bin-scribble-server
- [x] ./scripts/test-all.sh
- [x] Cargo.lock updated (if dependencies changed) — N/A, no dependency changes
- Verified: `cargo build` on `x86_64-pc-windows-msvc` compiles (previously E0308);