### PR TITLE
Update audio dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,12 +68,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
-name = "arrayvec"
-version = "0.7.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f02882884d3e1bc524fb12c79f107f6ad0e1cfd498c536ffb494301740995dfe"
-
-[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -87,31 +81,61 @@ checksum = "f93ebbf82d06013f4c41fe71303feb980cddd78496d904d06be627972de51a24"
 
 [[package]]
 name = "audioadapter"
-version = "2.0.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98e72b98fa467adcb7a88c5d1b8b686193185c81b9bf9c3fa3ac3524180cd55c"
+checksum = "91f87b70b051c5866680ad79f6743a42ccab264c009d1a71f4d33a3872ae60c8"
 dependencies = [
  "audio-core",
- "libm",
+ "num-traits",
+]
+
+[[package]]
+name = "audioadapter"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c75c3943c6c7279bb25a449a8d1727480730ab2efd7b6fd5d6ca51927096e6e4"
+dependencies = [
+ "audio-core",
  "num-traits",
 ]
 
 [[package]]
 name = "audioadapter-buffers"
-version = "2.0.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6af89882334c4e501faa08992888593ada468f9e1ab211635c32f9ada7786e0"
+checksum = "9097d67933fb083d382ce980430afdb758aada60846010aee6be068c06cef0ca"
 dependencies = [
- "audioadapter",
- "audioadapter-sample",
+ "audioadapter 3.0.0",
+ "audioadapter-sample 3.0.0",
+ "num-traits",
+]
+
+[[package]]
+name = "audioadapter-buffers"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ece3390b6eb40379094843a1da5aaccc34bc0d85a8cbf68d09fe092fee6de29e"
+dependencies = [
+ "audioadapter 4.0.0",
+ "audioadapter-sample 4.0.0",
  "num-traits",
 ]
 
 [[package]]
 name = "audioadapter-sample"
-version = "2.0.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e9a3d502fec0b21aa420febe0b110875cf8a7057c49e83a0cace1df6a73e03e"
+checksum = "34ab94f2bc04a14e1f49ee5f222f66460e8a1b51627bdfedf34eed394d747938"
+dependencies = [
+ "audio-core",
+ "num-traits",
+]
+
+[[package]]
+name = "audioadapter-sample"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1592f90413568e259413c21a41a3d571feb1774255c209e7966d98f9db708c90"
 dependencies = [
  "audio-core",
  "num-traits",
@@ -210,7 +234,7 @@ version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags",
  "cexpr",
  "clang-sys",
  "itertools",
@@ -223,12 +247,6 @@ dependencies = [
  "shlex 1.3.0",
  "syn",
 ]
-
-[[package]]
-name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -940,12 +958,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libm"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1356,7 +1368,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags",
 ]
 
 [[package]]
@@ -1381,6 +1393,12 @@ dependencies = [
  "memchr",
  "regex-syntax",
 ]
+
+[[package]]
+name = "regex-lite"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
 
 [[package]]
 name = "regex-syntax"
@@ -1441,12 +1459,12 @@ dependencies = [
 
 [[package]]
 name = "rubato"
-version = "1.0.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90173154a8a14e6adb109ea641743bc95ec81c093d94e70c6763565f7108ebeb"
+checksum = "d4be9c88e3d722d3d36939e41941f6b6f52810c1235bf19998a7d4535b402892"
 dependencies = [
- "audioadapter",
- "audioadapter-buffers",
+ "audioadapter 3.0.0",
+ "audioadapter-buffers 3.0.0",
  "num-complex",
  "num-integer",
  "num-traits",
@@ -1490,7 +1508,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1613,8 +1631,8 @@ name = "scribble"
 version = "0.5.4"
 dependencies = [
  "anyhow",
- "audioadapter",
- "audioadapter-buffers",
+ "audioadapter 4.0.0",
+ "audioadapter-buffers 4.0.0",
  "axum",
  "clap",
  "futures-util",
@@ -1644,7 +1662,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -1834,9 +1852,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "symphonia"
-version = "0.5.5"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5773a4c030a19d9bfaa090f49746ff35c75dfddfa700df7a5939d5e076a57039"
+checksum = "1758d6c853020a7244de03cc3e0185eaea3f58715122422dd3cc7452e6d4c16a"
 dependencies = [
  "lazy_static",
  "symphonia-bundle-flac",
@@ -1857,44 +1875,44 @@ dependencies = [
 
 [[package]]
 name = "symphonia-bundle-flac"
-version = "0.5.5"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91565e180aea25d9b80a910c546802526ffd0072d0b8974e3ebe59b686c9976"
+checksum = "ee69ad01236a67260b82fd1ff9790dd75ead29f2f46af145e63b7e72273e0e03"
 dependencies = [
  "log",
+ "symphonia-common",
  "symphonia-core",
  "symphonia-metadata",
- "symphonia-utils-xiph",
 ]
 
 [[package]]
 name = "symphonia-bundle-mp3"
-version = "0.5.5"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4872dd6bb56bf5eac799e3e957aa1981086c3e613b27e0ac23b176054f7c57ed"
+checksum = "350f1f2f2e19ad4dd315db94304d1eb361b29af070681f94e51b8fdaad769546"
 dependencies = [
  "lazy_static",
  "log",
  "symphonia-core",
- "symphonia-metadata",
 ]
 
 [[package]]
 name = "symphonia-codec-aac"
-version = "0.5.5"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c263845aa86881416849c1729a54c7f55164f8b96111dba59de46849e73a790"
+checksum = "f1979c515a76371b186aad2feff5f23e21cbec775bf95de08bf1e3af92a2ad76"
 dependencies = [
  "lazy_static",
  "log",
+ "symphonia-common",
  "symphonia-core",
 ]
 
 [[package]]
 name = "symphonia-codec-adpcm"
-version = "0.5.5"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dddc50e2bbea4cfe027441eece77c46b9f319748605ab8f3443350129ddd07f"
+checksum = "4ebbdfd76d6cc5a601c6292a44357c5b7c82f2cd7cdc0f171421f5c5cff0ea1f"
 dependencies = [
  "log",
  "symphonia-core",
@@ -1902,19 +1920,20 @@ dependencies = [
 
 [[package]]
 name = "symphonia-codec-alac"
-version = "0.5.5"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8413fa754942ac16a73634c9dfd1500ed5c61430956b33728567f667fdd393ab"
+checksum = "3a149cbfc7fb5c405d123a273227d31de17138419552112bf1aa7b73e65827b8"
 dependencies = [
  "log",
+ "symphonia-common",
  "symphonia-core",
 ]
 
 [[package]]
 name = "symphonia-codec-pcm"
-version = "0.5.5"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e89d716c01541ad3ebe7c91ce4c8d38a7cf266a3f7b2f090b108fb0cb031d95"
+checksum = "50baee168f0e9dcf6ba7fc06e8b57eb62072a4490cc7cf13af77e72baae5d328"
 dependencies = [
  "log",
  "symphonia-core",
@@ -1922,82 +1941,93 @@ dependencies = [
 
 [[package]]
 name = "symphonia-codec-vorbis"
-version = "0.5.5"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f025837c309cd69ffef572750b4a2257b59552c5399a5e49707cc5b1b85d1c73"
+checksum = "45b07b4423cd8e0fc472575909a5554b12c2f58e3c190b38c24f042e732fd8de"
+dependencies = [
+ "log",
+ "symphonia-common",
+ "symphonia-core",
+]
+
+[[package]]
+name = "symphonia-common"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8257891ffa7f05e02b58f4761e2abf7e5278c8744fd59e981559e050f86eef55"
 dependencies = [
  "log",
  "symphonia-core",
- "symphonia-utils-xiph",
+ "symphonia-metadata",
 ]
 
 [[package]]
 name = "symphonia-core"
-version = "0.5.5"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea00cc4f79b7f6bb7ff87eddc065a1066f3a43fe1875979056672c9ef948c2af"
+checksum = "95ec293b5f288383b72a7bffcade6b2860b642cf66f28b3bd5967349a49938b1"
 dependencies = [
- "arrayvec",
- "bitflags 1.3.2",
+ "bitflags",
  "bytemuck",
  "lazy_static",
  "log",
+ "num-complex",
+ "rustfft",
+ "smallvec",
 ]
 
 [[package]]
 name = "symphonia-format-caf"
-version = "0.5.5"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8faf379316b6b6e6bbc274d00e7a592e0d63ff1a7e182ce8ba25e24edd3d096"
+checksum = "cde3ca76633d3400ab57195456c09f8a58d775ff5452329f3f212b6efc8622f5"
 dependencies = [
  "log",
+ "symphonia-common",
  "symphonia-core",
- "symphonia-metadata",
 ]
 
 [[package]]
 name = "symphonia-format-isomp4"
-version = "0.5.5"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "243739585d11f81daf8dac8d9f3d18cc7898f6c09a259675fc364b382c30e0a5"
+checksum = "2d179a01305b3505940135a9f0180d6ef4b487912748fe97554756f120fbd05e"
 dependencies = [
- "encoding_rs",
  "log",
+ "symphonia-common",
  "symphonia-core",
  "symphonia-metadata",
- "symphonia-utils-xiph",
 ]
 
 [[package]]
 name = "symphonia-format-mkv"
-version = "0.5.5"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "122d786d2c43a49beb6f397551b4a050d8229eaa54c7ddf9ee4b98899b8742d0"
+checksum = "fb17713e134f5ad316c2690fa3104590ccc85842cdbcf82c3cd1a845cb08aa74"
 dependencies = [
  "lazy_static",
  "log",
+ "symphonia-common",
  "symphonia-core",
- "symphonia-metadata",
- "symphonia-utils-xiph",
 ]
 
 [[package]]
 name = "symphonia-format-ogg"
-version = "0.5.5"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b4955c67c1ed3aa8ae8428d04ca8397fbef6a19b2b051e73b5da8b1435639cb"
+checksum = "b05a67e02b1e4fca1a261ba4fe06910a9357489ad8c36aafdd2960e9c6559433"
 dependencies = [
  "log",
+ "symphonia-common",
  "symphonia-core",
  "symphonia-metadata",
- "symphonia-utils-xiph",
 ]
 
 [[package]]
 name = "symphonia-format-riff"
-version = "0.5.5"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2d7c3df0e7d94efb68401d81906eae73c02b40d5ec1a141962c592d0f11a96f"
+checksum = "17424452a777666d3eaf09a5c651029b15b6a333812fcc5b5474f2a3f0cff3f0"
 dependencies = [
  "extended",
  "log",
@@ -2007,24 +2037,15 @@ dependencies = [
 
 [[package]]
 name = "symphonia-metadata"
-version = "0.5.5"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36306ff42b9ffe6e5afc99d49e121e0bd62fe79b9db7b9681d48e29fa19e6b16"
+checksum = "a31acf5cd623398a6208e2225d18f4b20f761c55098a796a5247ad516a4a8681"
 dependencies = [
- "encoding_rs",
  "lazy_static",
  "log",
+ "regex-lite",
+ "smallvec",
  "symphonia-core",
-]
-
-[[package]]
-name = "symphonia-utils-xiph"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee27c85ab799a338446b68eec77abf42e1a6f1bb490656e121c6e27bfbab9f16"
-dependencies = [
- "symphonia-core",
- "symphonia-metadata",
 ]
 
 [[package]]
@@ -2217,7 +2238,7 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags",
  "bytes",
  "futures-util",
  "http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,10 +57,10 @@ reqwest = { version = "0.13.1", optional = true, default-features = false, featu
   "blocking",
   "rustls",
 ] }
-audioadapter = "2"
-audioadapter-buffers = "2"
-rubato = "1.0.1"
-symphonia = { version = "0.5", features = ["all"] }
+audioadapter = "4.0.0"
+audioadapter-buffers = "4.0.0"
+rubato = "3.0.0"
+symphonia = { version = "0.6.0", features = ["all"] }
 tempfile = "3"
 prometheus = { version = "0.14", optional = true }
 tower-http = { version = "0.6", optional = true, features = [

--- a/src/audio_pipeline.rs
+++ b/src/audio_pipeline.rs
@@ -11,20 +11,20 @@
 //! - `finalize()` should be called at end-of-stream to flush any remaining resampler input.
 
 use anyhow::{Context, Result, anyhow, bail};
-use audioadapter_buffers::direct::SequentialSliceOfVecs;
+use rubato::audioadapter_buffers::direct::SequentialSliceOfVecs;
 use rubato::{
     Async, FixedAsync, Resampler, SincInterpolationParameters, SincInterpolationType,
     WindowFunction,
 };
-use symphonia::core::audio::{AudioBufferRef, SampleBuffer};
+use symphonia::core::audio::GenericAudioBufferRef;
 
 /// Scribble's target mono sample rate (Hz).
 pub const TARGET_SAMPLE_RATE: u32 = 16_000;
 
 /// A small stateful pipeline that converts decoded audio into mono 16 kHz `f32` chunks.
 pub struct AudioPipeline {
-    // Scratch buffer used to copy decoded PCM into an interleaved `Vec<f32>`.
-    sample_buf_f32: Option<SampleBuffer<f32>>,
+    // Scratch buffer used to copy decoded PCM into interleaved `f32` samples.
+    sample_buf_f32: Vec<f32>,
 
     // Lazily initialized resampler (only needed when the source sample rate != 16 kHz).
     resampler: Option<Async<f32>>,
@@ -50,7 +50,7 @@ impl AudioPipeline {
     /// Create a new audio pipeline with empty internal buffers.
     pub fn new() -> Self {
         Self {
-            sample_buf_f32: None,
+            sample_buf_f32: Vec::new(),
             resampler: None,
             mono_src_acc: Vec::new(),
             resample_in: vec![Vec::new()],
@@ -64,14 +64,13 @@ impl AudioPipeline {
     /// Returning `Ok(false)` signals “stop early”.
     pub fn push_decoded_and_emit(
         &mut self,
-        decoded: &AudioBufferRef<'_>,
+        decoded: &GenericAudioBufferRef<'_>,
         target_chunk_frames: usize,
         mut emit: impl FnMut(&[f32]) -> Result<bool>,
     ) -> Result<()> {
-        let (interleaved, src_rate, channels) =
-            decoded_to_interleaved_f32(decoded, &mut self.sample_buf_f32)?;
+        let (src_rate, channels) = decoded_to_interleaved_f32(decoded, &mut self.sample_buf_f32)?;
 
-        let mono_src = downmix_to_mono(&interleaved, channels);
+        let mono_src = downmix_to_mono(&self.sample_buf_f32, channels);
 
         // Fast path: already at the target sample rate.
         if src_rate == TARGET_SAMPLE_RATE {
@@ -224,38 +223,18 @@ impl AudioPipeline {
 }
 
 fn decoded_to_interleaved_f32(
-    decoded: &AudioBufferRef<'_>,
-    sample_buf_f32: &mut Option<SampleBuffer<f32>>,
-) -> Result<(Vec<f32>, u32, usize)> {
-    ensure_sample_buffer(decoded, sample_buf_f32);
+    decoded: &GenericAudioBufferRef<'_>,
+    sample_buf_f32: &mut Vec<f32>,
+) -> Result<(u32, usize)> {
+    decoded.copy_to_vec_interleaved(sample_buf_f32);
 
-    let buf = sample_buf_f32
-        .as_mut()
-        .ok_or_else(|| anyhow!("sample buffer not initialized"))?;
-
-    // Copy decoded PCM into our interleaved scratch buffer.
-    buf.copy_interleaved_ref(decoded.clone());
-
-    let src_rate = decoded.spec().rate;
-    let channels = decoded.spec().channels.count();
+    let src_rate = decoded.spec().rate();
+    let channels = decoded.spec().channels().count();
     if channels == 0 {
         bail!("decoded audio had zero channels");
     }
 
-    Ok((buf.samples().to_vec(), src_rate, channels))
-}
-
-fn ensure_sample_buffer(
-    decoded: &AudioBufferRef<'_>,
-    sample_buf_f32: &mut Option<SampleBuffer<f32>>,
-) {
-    if sample_buf_f32.is_some() {
-        return;
-    }
-
-    let spec = *decoded.spec();
-    let duration = decoded.capacity() as u64;
-    *sample_buf_f32 = Some(SampleBuffer::<f32>::new(duration, spec));
+    Ok((src_rate, channels))
 }
 
 /// Downmix interleaved samples into mono by averaging channels.

--- a/src/bin/scribble-server/main.rs
+++ b/src/bin/scribble-server/main.rs
@@ -321,10 +321,10 @@ fn probe_source_and_pick_default_track(
     Box<dyn symphonia::core::formats::FormatReader>,
     symphonia::core::formats::Track,
 )> {
-    use symphonia::core::codecs::CODEC_TYPE_NULL;
+    use symphonia::core::codecs::audio::CODEC_ID_NULL_AUDIO;
+    use symphonia::core::formats::probe::Hint;
     use symphonia::core::io::{MediaSourceStream, MediaSourceStreamOptions};
     use symphonia::core::meta::MetadataOptions;
-    use symphonia::core::probe::Hint;
 
     let mss_opts = MediaSourceStreamOptions {
         buffer_len: 256 * 1024,
@@ -340,17 +340,23 @@ fn probe_source_and_pick_default_track(
     let format_opts: symphonia::core::formats::FormatOptions = Default::default();
     let metadata_opts: MetadataOptions = Default::default();
 
-    let probed = symphonia::default::get_probe()
-        .format(&hint, mss, &format_opts, &metadata_opts)
+    let format = symphonia::default::get_probe()
+        .probe(&hint, mss, format_opts, metadata_opts)
         .map_err(|e| anyhow!(e))
         .context("failed to probe media stream")?;
-
-    let format = probed.format;
 
     let track = format
         .tracks()
         .iter()
-        .find(|t| t.codec_params.codec != CODEC_TYPE_NULL && t.codec_params.sample_rate.is_some())
+        .find(|track| {
+            track
+                .codec_params
+                .as_ref()
+                .and_then(|params| params.audio())
+                .is_some_and(|params| {
+                    params.codec != CODEC_ID_NULL_AUDIO && params.sample_rate.is_some()
+                })
+        })
         .cloned()
         .ok_or_else(|| anyhow!("no audio track found"))?;
 

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -11,10 +11,11 @@
 //! demux → resample → VAD → Whisper, without worrying about codec edge cases.
 
 use anyhow::{Context, Result, anyhow};
-use symphonia::core::audio::AudioBufferRef;
-use symphonia::core::codecs::{Decoder, DecoderOptions};
+use symphonia::core::audio::GenericAudioBufferRef;
+use symphonia::core::codecs::audio::{AudioDecoder, AudioDecoderOptions};
 use symphonia::core::errors::Error as SymphoniaError;
-use symphonia::core::formats::{Packet, Track};
+use symphonia::core::formats::Track;
+use symphonia::core::packet::Packet;
 
 /// Create a decoder for the given audio track.
 ///
@@ -23,11 +24,16 @@ use symphonia::core::formats::{Packet, Track};
 /// Fails if:
 /// - the codec is unsupported
 /// - the codec parameters are invalid
-pub fn make_decoder_for_track(track: &Track) -> Result<Box<dyn Decoder>> {
-    let decoder_opts: DecoderOptions = Default::default();
+pub fn make_decoder_for_track(track: &Track) -> Result<Box<dyn AudioDecoder>> {
+    let decoder_opts: AudioDecoderOptions = Default::default();
+    let codec_params = track
+        .codec_params
+        .as_ref()
+        .and_then(|params| params.audio())
+        .ok_or_else(|| anyhow!("audio track is missing audio codec parameters"))?;
 
     symphonia::default::get_codecs()
-        .make(&track.codec_params, &decoder_opts)
+        .make_audio_decoder(codec_params, &decoder_opts)
         .map_err(|e| anyhow!(e))
         .context("failed to create decoder for audio track")
 }
@@ -47,9 +53,9 @@ pub fn make_decoder_for_track(track: &Track) -> Result<Box<dyn Decoder>> {
 /// - `IoError`     → treat as end-of-stream (streaming-friendly)
 /// - other errors  → bubble up with context
 pub fn decode_packet_and_then(
-    decoder: &mut Box<dyn Decoder>,
+    decoder: &mut Box<dyn AudioDecoder>,
     packet: &Packet,
-    mut on_decoded: impl FnMut(AudioBufferRef<'_>) -> Result<()>,
+    mut on_decoded: impl FnMut(GenericAudioBufferRef<'_>) -> Result<()>,
 ) -> Result<bool> {
     match decoder.decode(packet) {
         Ok(buf) => {

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -93,7 +93,7 @@ fn decode_impl(
         };
 
         // Ignore packets from non-audio tracks.
-        if packet.track_id() != track.id {
+        if packet.track_id != track.id {
             continue;
         }
 

--- a/src/demux.rs
+++ b/src/demux.rs
@@ -10,12 +10,13 @@
 //! - Provide a `next_packet` helper that treats IO errors as end-of-stream
 
 use anyhow::{Context, Result, anyhow};
-use symphonia::core::codecs::CODEC_TYPE_NULL;
+use symphonia::core::codecs::audio::CODEC_ID_NULL_AUDIO;
 use symphonia::core::errors::Error as SymphoniaError;
-use symphonia::core::formats::{FormatOptions, FormatReader, Packet, Track};
+use symphonia::core::formats::probe::Hint;
+use symphonia::core::formats::{FormatOptions, FormatReader, Track};
 use symphonia::core::io::{MediaSource, MediaSourceStream, MediaSourceStreamOptions};
 use symphonia::core::meta::MetadataOptions;
-use symphonia::core::probe::Hint;
+use symphonia::core::packet::Packet;
 
 /// Probe the container and pick a default audio track.
 ///
@@ -44,17 +45,23 @@ pub fn probe_source_and_pick_default_track(
     let format_opts: FormatOptions = Default::default();
     let metadata_opts: MetadataOptions = Default::default();
 
-    let probed = symphonia::default::get_probe()
-        .format(&hint, mss, &format_opts, &metadata_opts)
+    let format = symphonia::default::get_probe()
+        .probe(&hint, mss, format_opts, metadata_opts)
         .map_err(|e| anyhow!(e))
         .context("failed to probe media stream")?;
-
-    let format = probed.format;
 
     let track = format
         .tracks()
         .iter()
-        .find(|t| t.codec_params.codec != CODEC_TYPE_NULL && t.codec_params.sample_rate.is_some())
+        .find(|track| {
+            track
+                .codec_params
+                .as_ref()
+                .and_then(|params| params.audio())
+                .is_some_and(|params| {
+                    params.codec != CODEC_ID_NULL_AUDIO && params.sample_rate.is_some()
+                })
+        })
         .cloned()
         .ok_or_else(|| anyhow!("no audio track found"))?;
 
@@ -68,7 +75,7 @@ pub fn probe_source_and_pick_default_track(
 /// - other errors are surfaced with context
 pub fn next_packet(format: &mut Box<dyn FormatReader>) -> Result<Option<Packet>> {
     match format.next_packet() {
-        Ok(p) => Ok(Some(p)),
+        Ok(packet) => Ok(packet),
         Err(SymphoniaError::IoError(_)) => Ok(None),
         Err(e) => Err(anyhow!(e)).context("failed reading packet"),
     }


### PR DESCRIPTION
## Summary

Upgrade the audio decoding and resampling dependency stack:

- `audioadapter` to 4.0.0
- `audioadapter-buffers` to 4.0.0
- `rubato` to 3.0.0
- `symphonia` to 0.6.0

Migrate decoding, probing, packet handling, and audio-buffer conversion to the new Symphonia APIs.

## Behavior changes

No intentional user-facing behavior changes. Audio decoding, downmixing, resampling, and streaming transcription behavior remain unchanged.

## Edge cases

- Missing audio codec parameters now produce an explicit error.
- End-of-stream handling uses Symphonia 0.6’s optional packet result.
- Recoverable decode and I/O errors continue to skip the affected packet.
- Track selection still requires a known audio codec and sample rate.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --features bin-scribble-cli,bin-model-downloader,bin-scribble-server -- -D warnings`
- `cargo check --features bin-scribble-cli,bin-model-downloader,bin-scribble-server`
- `./scripts/test-all.sh`

All 55 tests and doc tests pass.

## Follow-up

Rubato 3 depends on audioadapter 3 internally, so both audioadapter 3 and 4 are currently present in the dependency graph. A future Rubato upgrade can remove this duplication once it supports audioadapter 4.