### PR TITLE
Upgrade tower-http to 0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1435,7 +1435,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower",
- "tower-http",
+ "tower-http 0.6.11",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -1649,7 +1649,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
- "tower-http",
+ "tower-http 0.7.0",
  "tracing",
  "tracing-subscriber",
  "uuid",
@@ -2244,12 +2244,28 @@ dependencies = [
  "http",
  "http-body",
  "pin-project-lite",
- "tokio",
  "tower",
  "tower-layer",
  "tower-service",
- "tracing",
  "url",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b11f75e912b0c2be01b63d8cf8057b8c3f97cf34abb3d431a3a4c8675498e233"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "http",
+ "http-body",
+ "percent-encoding",
+ "pin-project-lite",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ rubato = "3.0.0"
 symphonia = { version = "0.6.0", features = ["all"] }
 tempfile = "3"
 prometheus = { version = "0.14", optional = true }
-tower-http = { version = "0.6", optional = true, features = [
+tower-http = { version = "0.7.0", optional = true, features = [
   "trace",
   "timeout",
 ] }


### PR DESCRIPTION
## Summary

Upgrade the server’s `tower-http` dependency from 0.6 to 0.7.0.

## Behavior changes

No intentional runtime behavior changes. Existing tracing and request timeout middleware remain configured as before.

`reqwest` continues to use `tower-http` 0.6.11 transitively.

## Edge cases

No new edge cases identified.

## Verification

- `cargo fmt --all -- --check`
- Full-feature `cargo check`
- Full-feature Clippy with warnings denied
- `./scripts/test-all.sh`

## Follow-up work

None.